### PR TITLE
Untitled

### DIFF
--- a/scripts/pw
+++ b/scripts/pw
@@ -79,7 +79,7 @@ else:
 results = [e for e in entries if e['canonical_path'].find(query_path) != -1 and ((not query_user) or (e.has_key('U') and e['U'].find(query_user) != -1))]
 
 # print results
-HAVE_COLOR_TERM = os.environ.has_key('TERM') and os.environ['TERM'] == 'xterm-color'
+HAVE_COLOR_TERM = os.getenv('COLORTERM') or 'color' in os.getenv('TERM', 'default')
 
 def wrap_in_color(text, color_code):
   return '\x1b[%sm%s\x1b[0m' % (color_code, text) if HAVE_COLOR_TERM else text


### PR DESCRIPTION
This allows `pw`'s colour mode to work in more terminal types.  For my own use I only care about [rxvt-unicode](http://software.schmorp.de/pkg/rxvt-unicode.html), but this method works with other terms too.

Thanks,

James
